### PR TITLE
dat-modules: fix link to transformer

### DIFF
--- a/dat-modules.md
+++ b/dat-modules.md
@@ -2,7 +2,7 @@
 This is a list of modules (github repositories) that are part of Dat Project. They are all covered by the [Dat Project License](dat-license.md) and [CLA](dat-cla.md).
 
 - [maxogden/dat](https://github.com/maxogden/dat)
-- [jbenet/transformer](https://github.com/maxogden/dat)
+- [jbenet/transformer](https://github.com/jbenet/transformer)
 
 TODO: make this a full list.
 


### PR DESCRIPTION
The link wasn't pointing to the correct repo. Not sure what the status of transformer is though, it appears it hasn't been touched in a while. Hopefully this is helpful. Thanks!
